### PR TITLE
Fixes object structure when getting group info.

### DIFF
--- a/lib/Auth/Source/scoutnetauth.php
+++ b/lib/Auth/Source/scoutnetauth.php
@@ -79,8 +79,8 @@ class sspmod_scoutnetmodule_Auth_Source_scoutnetauth extends sspmod_core_Auth_Us
         foreach ($memberResultObj->memberships as $memberships) {
             foreach ($memberships as $groupkey => $group) {
                 if ($group->is_primary) {
-                    $group_name = $group->group->name;
-                    $group_no = $group->group->group_no;
+                    $group_name = $group->name;
+                    $group_no = $group->group_no;
                     $group_id = $groupkey;
                 }
             }


### PR DESCRIPTION
The JSON structure when getting the membership object from /api/get/profile seems to have changed.
The code assumes each group object is:
```
"<group_id>": {
  "group": {
    ...
    "name": string,
    "is_primary": bool,
    "group_no": int,
    ...
  }
}
```
But the "group" object has been removed like so:
```
"<group_id>": {
  ...
  "name": string,
  "is_primary": bool,
  "group_no": int,
  ...
}
```