### PR TITLE
bugfix: invert boolean above_15, see Issue #7

### DIFF
--- a/lib/Auth/Source/scoutnetauth.php
+++ b/lib/Auth/Source/scoutnetauth.php
@@ -103,7 +103,7 @@ class sspmod_scoutnetmodule_Auth_Source_scoutnetauth extends sspmod_core_Auth_Us
         $bday = new DateTime($memberResultObj->dob);
         $today = new DateTime('00:00:00');
         $age = $today->diff($bday)->y;
-        $above_15 = (int)($age < 15);
+        $above_15 = (int)($age > 15);
 
         $attributes = [
             'uid' => [$authResultObj->member->member_no],


### PR DESCRIPTION
Current: `($age < 15)`
above_15
* is 0/false if age is 15 or above
* is 1/true if age is 14 or bellow

PR: `($age > 15)`
above_15
* is 1/true if age is 16 or above
* is 0/false if age is 15 or bellow

Depening on how it supose to be use, `($age >= 15)` may be right instead:
* is 1/true if age is 15 or above
* is 0/false if age is 14 or bellow

Is you above 15 years when your 15 years and 1 secound old? Or first when your 16 years old.
See Issue #7