### PR TITLE
Explicitly set User-Agent

### DIFF
--- a/lib/Auth/Source/scoutnetauth.php
+++ b/lib/Auth/Source/scoutnetauth.php
@@ -35,6 +35,7 @@ class sspmod_scoutnetmodule_Auth_Source_scoutnetauth extends UserPassBase
             'http' =>
                 [
                     'method' => 'POST',
+                    'user_agent' => 'scoutid',
                     'header' => 'Content-type: application/x-www-form-urlencoded',
                     'content' => $postData
                 ]
@@ -71,6 +72,7 @@ class sspmod_scoutnetmodule_Auth_Source_scoutnetauth extends UserPassBase
         $options = [
             'http' => [
                 'method' => 'POST',
+                'user_agent' => 'scoutid',
                 'header' => "Authorization: Bearer {$authResultObj->token}\r\n"
             ]
         ];
@@ -96,6 +98,7 @@ class sspmod_scoutnetmodule_Auth_Source_scoutnetauth extends UserPassBase
         $options = [
             'http' => [
                 'method' => 'POST',
+                'user_agent' => 'scoutid',
                 'header' => "Authorization: Bearer {$authResultObj->token}\r\n"
             ]
         ];


### PR DESCRIPTION
The user agent is used by Membernet JWT signing, and if different user
agents are used when requesting and using a JWT signature verification
will fail.